### PR TITLE
Patch urllib3 from 1.26.4 to >:1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # requirements.txt
 requests==2.28.2
-urllib3==1.26.4  # Vulnerable version (CVE-2023-32681)
+urllib3>=>:1.26.5
 pytest==7.3.1
 mock==5.0.2


### PR DESCRIPTION
This pull request upgrades `urllib3` from `1.26.4` to `>:1.26.5` to address a potential vulnerability.